### PR TITLE
issue-3: Fixed bug caused by "eager evaluation" of the plugin consumer.

### DIFF
--- a/libs-catalog-generator/src/main/kotlin/CatalogGeneratorPlugin.kt
+++ b/libs-catalog-generator/src/main/kotlin/CatalogGeneratorPlugin.kt
@@ -5,6 +5,7 @@ import org.gradle.api.initialization.Settings
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.register
 import org.gradle.util.GradleVersion
@@ -61,10 +62,6 @@ import javax.inject.Inject
 class CatalogGeneratorPlugin @Inject constructor(
     private val objects: ObjectFactory
 ) : Plugin<Any> {
-    /**
-     * Holds the catalog file location once found. Null until the catalog file is located.
-     */
-    private var catalogFileOrNull: File? = null
     private val currentVersion = GradleVersion.current()
     private val gradle85 = GradleVersion.version("8.5")
     private val gradle70 = GradleVersion.version("7.0")
@@ -100,12 +97,14 @@ class CatalogGeneratorPlugin @Inject constructor(
                 }
 
                 gradle.settingsEvaluated {
-                    val catalogPath = target.findCatalogLocation(config)
-                    val catalogSource = fileReference(catalogPath)
+                    // Use provider to get catalog file - evaluated here after settings are fully configured
+                    val catalogFileProvider = target.findCatalogLocationProvider(config)
+                    val catalogSource = catalogFileProvider.get()
+                    val catalogNameValue = config.catalogName.orElse(CATALOG_NAME).get()
 
                     dependencyResolutionManagement {
                         versionCatalogs {
-                            create(config.catalogName.getOrElse(CATALOG_NAME)) {
+                            create(catalogNameValue) {
                                 from(
                                     fileCollectionFrom(catalogSource)
                                 )
@@ -125,48 +124,68 @@ class CatalogGeneratorPlugin @Inject constructor(
         }
     }
 
-    private fun Settings.findCatalogLocation(config: CatalogGenConfig): String {
-        val location = config.catalogTomlLocation.getOrElse(TOML_CATALOG_LOCATION)
-        var currentDir = rootDirectory()
-
-        while (currentDir.exists()) {
-            val file = File(currentDir, location)
-            if (file.exists()) {
-                catalogFileOrNull = file
-                return file.absolutePath
+    /**
+     * Creates a lazy provider that finds the catalog file location.
+     * The search is deferred until the provider is resolved, ensuring user configuration is respected.
+     */
+    private fun Settings.findCatalogLocationProvider(config: CatalogGenConfig): Provider<File> {
+        val rootDir = rootDirectory()
+        return config.catalogTomlLocation
+            .orElse(TOML_CATALOG_LOCATION)
+            .map { location ->
+                findCatalogFileInHierarchy(rootDir, location)
+                    ?: throw FileNotFoundException(
+                        "Could not find $location in the project hierarchy. Please specify " +
+                                "the correct location in the settings.gradle.kts file using the " +
+                                "catalogTomlLocation property of the catalogGenerator extension: \n" +
+                                "catalogGenerator {\n" +
+                                "    catalogTomlLocation.set(\"path/to/your/catalog.toml\")\n" +
+                                "}"
+                    )
             }
-            currentDir = currentDir.parentFile ?: break
-        }
-        throw FileNotFoundException(
-            "Could not find $location in the project hierarchy. Please specify " +
-                    "the correct location in the settings.gradle.kts file using the " +
-                    "catalogTomlLocation property of the catalogGenerator extension: \n" +
-                    "catalogGenerator {\n" +
-                    "    catalogTomlLocation.set(\"path/to/your/catalog.toml\")\n" +
-                    "}" +
-                    ""
-        )
     }
 
-    private fun findCatalogLocationInProject(project: Project, config: CatalogGenConfig): File {
-        val location = config.catalogTomlLocation.getOrElse(TOML_CATALOG_LOCATION)
-        var currentDir = project.rootDir
+    /**
+     * Searches for a catalog file starting from the given directory and walking up the hierarchy.
+     * Returns null if not found.
+     */
+    private fun findCatalogFileInHierarchy(startDir: File, location: String): File? {
+        // If location is absolute, use it directly
+        val locationFile = File(location)
+        if (locationFile.isAbsolute) {
+            return if (locationFile.exists()) locationFile else null
+        }
 
-        while (currentDir.exists()) {
+        // Otherwise search up the directory hierarchy
+        var currentDir: File? = startDir
+        while (currentDir != null && currentDir.exists()) {
             val file = File(currentDir, location)
             if (file.exists()) {
                 return file
             }
-            currentDir = currentDir.parentFile ?: break
+            currentDir = currentDir.parentFile
         }
-        throw FileNotFoundException(
-            "Could not find $location in the project hierarchy. Please specify " +
-                    "the correct location in the build.gradle.kts file using the " +
-                    "catalogTomlLocation property of the catalogGenerator extension: \n" +
-                    "catalogGenerator {\n" +
-                    "    catalogTomlLocation.set(\"path/to/your/catalog.toml\")\n" +
-                    "}"
-        )
+        return null
+    }
+
+    /**
+     * Creates a lazy provider that finds the catalog file location for a project.
+     * The search is deferred until the provider is resolved, ensuring user configuration is respected.
+     */
+    private fun findCatalogLocationProviderInProject(project: Project, config: CatalogGenConfig): Provider<File> {
+        return config.catalogTomlLocation
+            .orElse(TOML_CATALOG_LOCATION)
+            .map { location ->
+                findCatalogFileInHierarchy(project.rootDir, location)
+                    ?: throw FileNotFoundException(
+                        "Could not find $location in the project hierarchy. Please specify " +
+                                "the correct location in the build.gradle.kts file using the " +
+                                "catalogTomlLocation property of the catalogGenerator extension: \n" +
+                                "catalogGenerator {\n" +
+                                "    catalogTomlLocation.set(\"path/to/your/catalog.toml\")\n" +
+                                "}"
+                    )
+            }
     }
 
     private fun applyPluginToProject(project: Project) {
@@ -177,8 +196,8 @@ class CatalogGeneratorPlugin @Inject constructor(
                 null
             } ?: project.extensions.create<CatalogGenConfig>(CATALOG_CONFIG_ACCESSOR)
 
-        // Get or find the catalog file
-        val catalogFile = catalogFileOrNull ?: findCatalogLocationInProject(project, config)
+        // Create a lazy provider for the catalog file - evaluated only when needed
+        val catalogFileProvider = findCatalogLocationProviderInProject(project, config)
 
         // Apply Kotlin plugin if not already applied, using string to avoid class reference
         if (!project.plugins.hasPlugin("org.jetbrains.kotlin.jvm")) {
@@ -194,11 +213,11 @@ class CatalogGeneratorPlugin @Inject constructor(
         }
 
         project.tasks.register<TypeSafeCatalogTask>(TypeSafeCatalogTask.NAME) {
-            catalogName.convention(config.catalogName.getOrElse(CATALOG_NAME))
+            // Use orElse to maintain lazy evaluation chain
+            catalogName.convention(config.catalogName.orElse(CATALOG_NAME))
+            // Wire the catalogFile lazily using the provider
             this.catalogFile.convention(
-                project.layout.projectDirectory.file(
-                    project.rootDir.toPath().relativize(catalogFile.toPath()).toString()
-                )
+                project.layout.file(catalogFileProvider)
             )
             project.layout.buildDirectory.file("generated-sources/kotlin-dsl-plugins/kotlin/GeneratedCatalog.kt")
                 .let(generatedSourcesFile::convention)

--- a/libs-catalog-generator/src/test/kotlin/CatalogGeneratorPluginIntegrationTest.kt
+++ b/libs-catalog-generator/src/test/kotlin/CatalogGeneratorPluginIntegrationTest.kt
@@ -346,6 +346,307 @@ class CatalogGeneratorPluginIntegrationTest {
             val generatedFile = File(testProjectDir, "build/generated-sources/kotlin-dsl-plugins/kotlin/GeneratedCatalog.kt")
             assertTrue(generatedFile.exists())
         }
+
+        @Test
+        @DisplayName("should work with absolute path to catalog file")
+        fun `works with absolute path to catalog file`() {
+            // Create catalog file in a custom location
+            val catalogFile = File(testProjectDir, "custom-location/libs.versions.toml").apply {
+                parentFile.mkdirs()
+                writeText(DEFAULT_CATALOG)
+            }
+
+            // Use absolute path in configuration
+            testProjectDir.createSettingsFile(
+                """
+                catalogGenerator {
+                    catalogTomlLocation.set("${catalogFile.absolutePath.replace("\\", "\\\\")}")
+                }
+                """.trimIndent()
+            )
+            testProjectDir.createBuildFile()
+
+            val result = GradleRunner.create()
+                .withProjectDir(testProjectDir)
+                .withArguments("generateTypeSafeCatalog", "--stacktrace")
+                .withPluginClasspath()
+                .build()
+
+            assertEquals(TaskOutcome.SUCCESS, result.task(":generateTypeSafeCatalog")?.outcome)
+
+            val generatedFile = File(testProjectDir, "build/generated-sources/kotlin-dsl-plugins/kotlin/GeneratedCatalog.kt")
+            assertTrue(generatedFile.exists(), "GeneratedCatalog.kt should exist")
+        }
+    }
+
+    @Nested
+    @DisplayName("Nested Project Structure (build-logic pattern)")
+    inner class NestedProjectStructure {
+
+        @Test
+        @DisplayName("should work with catalog in parent directory using relative path")
+        fun `works with catalog in parent directory using relative path`() {
+            // Simulate a build-logic/convention structure where:
+            // - Main project root has gradle/libs.versions.toml
+            // - build-logic/convention is a separate Gradle build that needs to access it
+
+            // Create the main project catalog at parent level
+            val parentDir = testProjectDir
+            File(parentDir, "gradle/libs.versions.toml").apply {
+                parentFile.mkdirs()
+                writeText(DEFAULT_CATALOG)
+            }
+
+            // Create the nested build-logic directory
+            val buildLogicDir = File(parentDir, "build-logic").apply { mkdirs() }
+
+            // Create settings for build-logic that references parent catalog with relative path
+            File(buildLogicDir, "settings.gradle.kts").writeText(
+                """
+                @file:Suppress("UnstableApiUsage")
+
+                rootProject.name = "build-logic"
+
+                plugins {
+                    id("de.felixlf.libs-catalog-generator")
+                }
+
+                catalogGenerator {
+                    // Use relative path to access catalog in parent directory
+                    catalogTomlLocation.set("../gradle/libs.versions.toml")
+                }
+
+                dependencyResolutionManagement {
+                    repositories {
+                        mavenCentral()
+                        gradlePluginPortal()
+                    }
+                }
+                """.trimIndent()
+            )
+
+            File(buildLogicDir, "build.gradle.kts").writeText(
+                """
+                plugins {
+                    `kotlin-dsl`
+                }
+                """.trimIndent()
+            )
+
+            val result = GradleRunner.create()
+                .withProjectDir(buildLogicDir)
+                .withArguments("generateTypeSafeCatalog", "--stacktrace")
+                .withPluginClasspath()
+                .build()
+
+            assertEquals(TaskOutcome.SUCCESS, result.task(":generateTypeSafeCatalog")?.outcome)
+
+            val generatedFile = File(buildLogicDir, "build/generated-sources/kotlin-dsl-plugins/kotlin/GeneratedCatalog.kt")
+            assertTrue(generatedFile.exists(), "GeneratedCatalog.kt should exist")
+        }
+
+        @Test
+        @DisplayName("should work with catalog in parent directory using absolute path via file()")
+        fun `works with catalog in parent directory using absolute path`() {
+            // Simulate a build-logic/convention structure with absolute path
+
+            // Create the main project catalog at parent level
+            val parentDir = testProjectDir
+            val catalogFile = File(parentDir, "gradle/libs.versions.toml").apply {
+                parentFile.mkdirs()
+                writeText(DEFAULT_CATALOG)
+            }
+
+            // Create the nested build-logic directory
+            val buildLogicDir = File(parentDir, "build-logic").apply { mkdirs() }
+
+            // Create settings for build-logic that references parent catalog with absolute path
+            File(buildLogicDir, "settings.gradle.kts").writeText(
+                """
+                @file:Suppress("UnstableApiUsage")
+
+                rootProject.name = "build-logic"
+
+                plugins {
+                    id("de.felixlf.libs-catalog-generator")
+                }
+
+                catalogGenerator {
+                    // Use absolute path (simulating what user would do with file().absolutePath)
+                    catalogTomlLocation.set("${catalogFile.absolutePath.replace("\\", "\\\\")}")
+                }
+
+                dependencyResolutionManagement {
+                    repositories {
+                        mavenCentral()
+                        gradlePluginPortal()
+                    }
+                }
+                """.trimIndent()
+            )
+
+            File(buildLogicDir, "build.gradle.kts").writeText(
+                """
+                plugins {
+                    `kotlin-dsl`
+                }
+                """.trimIndent()
+            )
+
+            val result = GradleRunner.create()
+                .withProjectDir(buildLogicDir)
+                .withArguments("generateTypeSafeCatalog", "--stacktrace")
+                .withPluginClasspath()
+                .build()
+
+            assertEquals(TaskOutcome.SUCCESS, result.task(":generateTypeSafeCatalog")?.outcome)
+
+            val generatedFile = File(buildLogicDir, "build/generated-sources/kotlin-dsl-plugins/kotlin/GeneratedCatalog.kt")
+            assertTrue(generatedFile.exists(), "GeneratedCatalog.kt should exist")
+        }
+
+        @Test
+        @DisplayName("should work with deeply nested project structure")
+        fun `works with deeply nested project structure`() {
+            // Simulate build-logic/convention pattern where convention is two levels down
+
+            // Create the main project catalog at root level
+            val rootDir = testProjectDir
+            File(rootDir, "gradle/libs.versions.toml").apply {
+                parentFile.mkdirs()
+                writeText(DEFAULT_CATALOG)
+            }
+
+            // Create deeply nested convention directory
+            val conventionDir = File(rootDir, "build-logic/convention").apply { mkdirs() }
+
+            // Create settings for convention that references root catalog
+            File(conventionDir, "settings.gradle.kts").writeText(
+                """
+                @file:Suppress("UnstableApiUsage")
+
+                rootProject.name = "convention"
+
+                plugins {
+                    id("de.felixlf.libs-catalog-generator")
+                }
+
+                catalogGenerator {
+                    // Path relative to convention dir going up two levels
+                    catalogTomlLocation.set("../../gradle/libs.versions.toml")
+                }
+
+                dependencyResolutionManagement {
+                    repositories {
+                        mavenCentral()
+                        gradlePluginPortal()
+                    }
+                }
+                """.trimIndent()
+            )
+
+            File(conventionDir, "build.gradle.kts").writeText(
+                """
+                plugins {
+                    `kotlin-dsl`
+                }
+                """.trimIndent()
+            )
+
+            val result = GradleRunner.create()
+                .withProjectDir(conventionDir)
+                .withArguments("generateTypeSafeCatalog", "--stacktrace")
+                .withPluginClasspath()
+                .build()
+
+            assertEquals(TaskOutcome.SUCCESS, result.task(":generateTypeSafeCatalog")?.outcome)
+
+            val generatedFile = File(conventionDir, "build/generated-sources/kotlin-dsl-plugins/kotlin/GeneratedCatalog.kt")
+            assertTrue(generatedFile.exists(), "GeneratedCatalog.kt should exist")
+        }
+
+        @Test
+        @DisplayName("should work with file() and rootDir pattern from user issue")
+        fun `works with file rootDir pattern from user issue`() {
+            // This test reproduces the exact pattern from the GitHub issue:
+            // catalogGenerator {
+            //     val catalogFileLocal = file("$rootDir/../gradle/libs.versions.toml")
+            //     catalogTomlLocation = catalogFileLocal.absolutePath
+            // }
+
+            // Create the main project catalog at parent level (simulating the real project root)
+            val parentDir = testProjectDir
+            File(parentDir, "gradle/libs.versions.toml").apply {
+                parentFile.mkdirs()
+                writeText(DEFAULT_CATALOG)
+            }
+
+            // Create the build-logic directory (this is where the plugin is applied)
+            val buildLogicDir = File(parentDir, "build-logic").apply { mkdirs() }
+
+            // Create settings using the exact pattern from the user's issue
+            File(buildLogicDir, "settings.gradle.kts").writeText(
+                """
+                @file:Suppress("UnstableApiUsage")
+
+                rootProject.name = "build-logic"
+
+                plugins {
+                    id("de.felixlf.libs-catalog-generator")
+                }
+
+                catalogGenerator {
+                    // This mimics the user's pattern:
+                    // val catalogFileLocal = file("${'$'}rootDir/../gradle/libs.versions.toml")
+                    // catalogTomlLocation = catalogFileLocal.absolutePath
+                    val catalogFileLocal = file("${'$'}rootDir/../gradle/libs.versions.toml")
+                    println("catalogFile = ${'$'}catalogFileLocal")
+                    catalogTomlLocation.set(catalogFileLocal.absolutePath)
+                    println("catalogTomlLocation after setting = ${'$'}{catalogTomlLocation.get()}")
+                }
+
+                dependencyResolutionManagement {
+                    repositories {
+                        mavenCentral()
+                        gradlePluginPortal()
+                    }
+                }
+                """.trimIndent()
+            )
+
+            File(buildLogicDir, "build.gradle.kts").writeText(
+                """
+                plugins {
+                    `kotlin-dsl`
+                }
+                """.trimIndent()
+            )
+
+            val result = GradleRunner.create()
+                .withProjectDir(buildLogicDir)
+                .withArguments("generateTypeSafeCatalog", "--stacktrace")
+                .withPluginClasspath()
+                .build()
+
+            // Verify the println outputs show correct values
+            assertTrue(
+                result.output.contains("catalogFile = ") && result.output.contains("libs.versions.toml"),
+                "Should print the catalog file path"
+            )
+            assertTrue(
+                result.output.contains("catalogTomlLocation after setting = ") && result.output.contains("libs.versions.toml"),
+                "Should print the catalogTomlLocation after setting"
+            )
+
+            assertEquals(TaskOutcome.SUCCESS, result.task(":generateTypeSafeCatalog")?.outcome)
+
+            val generatedFile = File(buildLogicDir, "build/generated-sources/kotlin-dsl-plugins/kotlin/GeneratedCatalog.kt")
+            assertTrue(generatedFile.exists(), "GeneratedCatalog.kt should exist")
+
+            // Verify the generated file contains expected content
+            val content = generatedFile.readText()
+            assertTrue(content.contains("projectlibs"), "Should contain default catalog name")
+        }
     }
 
     @Nested


### PR DESCRIPTION
Added unit tests, for the case, where relative and absolute paths are provided.